### PR TITLE
Global retry logic for interface connection

### DIFF
--- a/backend/plumber.go
+++ b/backend/plumber.go
@@ -150,7 +150,13 @@ func (i *Interface) retryConnection(reason string) error {
 	if i.retries > maxretries-1 {
 		return fmt.Errorf("%s: Last error: %s", errMaxRetriesReached, reason)
 	}
-	return i.Connect()
+	err := i.Connect()
+
+	if err != nil {
+		i.retries = 0
+	}
+
+	return err
 }
 
 func (i *Interface) Connect() error {
@@ -182,8 +188,6 @@ func (i *Interface) Connect() error {
 		newPeersSHA := extractPeersSHA(workingPeers)
 		if newPeersSHA == peersSHA {
 			time.Sleep(peercheckttl)
-			// reset the retry counter since this connection is established
-			i.retries = 0
 			continue
 		}
 		log.Println("The peer list changed, reconfiguring...")
@@ -254,8 +258,6 @@ func (i *Interface) Connect() error {
 		}
 
 		log.Println("Link up")
-		// reset the retries counter since this made it!
-		i.retries = 0
 	}
 
 	return nil

--- a/cmd/wirey/root.go
+++ b/cmd/wirey/root.go
@@ -20,12 +20,9 @@ var etcdBackend []string
 var httpBackend string
 var httpBackendBasicAuth string
 
-// rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:   "wirey",
 	Short: "manage local wireguard interfaces in a distributed system",
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
 	Run: func(cmd *cobra.Command, args []string) {
 		b, err := backendFactory()
 
@@ -36,7 +33,7 @@ var rootCmd = &cobra.Command{
 		privKeyBaseDir := filepath.Dir(privateKeyPath)
 		if _, err := os.Stat(privKeyBaseDir); os.IsNotExist(err) {
 			if err := os.Mkdir(privKeyBaseDir, 0600); err != nil {
-				log.Fatal("Unable to create the base directory for the wirey private key: %s - %s", privKeyBaseDir, err.Error())
+				log.Fatalf("Unable to create the base directory for the wirey private key: %s - %s", privKeyBaseDir, err.Error())
 			}
 		}
 


### PR DESCRIPTION
Better to have a retry logic,
this can be made configurable in the future if needed.


Signed-off-by: Lorenzo Fontana <lo@linux.com>