### PR TITLE
Hotfix: retires error check on connect should reset the counter only …

### DIFF
--- a/backend/plumber.go
+++ b/backend/plumber.go
@@ -152,7 +152,7 @@ func (i *Interface) retryConnection(reason string) error {
 	}
 	err := i.Connect()
 
-	if err != nil {
+	if err == nil {
 		i.retries = 0
 	}
 


### PR DESCRIPTION
…if no error occurred

Signed-off-by: Lorenzo Fontana <lo@linux.com>