### PR TITLE
Wirey version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 SHELL := /bin/bash
+COMMIT_NO := $(shell git rev-parse --short=7 HEAD 2> /dev/null || true)
+GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
+LDFLAGS=-ldflags "-s -X main.Version=${GIT_COMMIT}"
 
 all: build
 
 .PHONY: build
 build:
 	mkdir -p bin
-	go build -o bin/wirey ./cmd/wirey
+	go build ${LDFLAGS} -o bin/wirey ./cmd/wirey
 

--- a/cmd/wirey/root.go
+++ b/cmd/wirey/root.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+var Version string
+
 var rootCmd = &cobra.Command{
 	Use:   "wirey",
 	Short: "manage local wireguard interfaces in a distributed system",
@@ -69,7 +71,7 @@ func backendFactory() (backend.Backend, error) {
 
 	httpBackend := viper.GetString("http")
 	if len(httpBackend) != 0 {
-		b, err := backend.NewHTTPBackend(httpBackend)
+		b, err := backend.NewHTTPBackend(httpBackend, Version)
 		if err != nil {
 			return nil, err
 		}
@@ -110,7 +112,7 @@ func init() {
 	pflags.String("httpbasicauth", "", "basic auth for the http backend, in form username:password")
 	pflags.String("ifname", "wg0", "the name to use for the interface (must be the same in all the peers)")
 	pflags.String("ipaddr", "", "the ip for this node inside the tunnel, e.g: 10.0.0.3")
-	pflags.String("peerdiscoveryttl", "5s", "the time to wait to discover new peers using the configured backend")
+	pflags.String("peerdiscoveryttl", "30s", "the time to wait to discover new peers using the configured backend")
 	pflags.String("privatekeypath", "/etc/wirey/privkey", "the local path where to load the private key from, if empty, a private key will be generated.")
 
 	rootCmd.MarkFlagRequired("endpoint")

--- a/cmd/wirey/version.go
+++ b/cmd/wirey/version.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "print the current wirey version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("%s\n", Version)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Wirey now has a version command `wirey version` and send `wirey/version` as user agent when calling http backends.
Closes #16 